### PR TITLE
Bump log4j version to 2.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ Changelog
 
 This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
+1.3.4 (2022-01-04)
+-------------------
+
+**Added**
+
+**Fixed**
+
+**Dependencies**
+
+* org.apache.logging.log4j 2.17.0 -> 2.17.1 (addresses CVE-2021-44832)
+
+**Deprecated**
+
 1.3.3 (2021-12-20)
 -------------------
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   </parent>
   <groupId>life.qbic</groupId>
   <artifactId>project-manager-portlet</artifactId>
-  <version>1.3.3</version>
+  <version>1.3.4</version>
   <name>Project Manager Portlet</name>
   <url>https://github.com/qbicsoftware/project-manager-portlet</url>
   <description>Project manager portlet to view followed projects</description>
@@ -26,7 +26,7 @@
     <liferay.version>6.2.5</liferay.version>
     <liferay.maven.plugin.version>6.2.5</liferay.maven.plugin.version>
     <jetty.plugin.version>9.4.31.v20200723</jetty.plugin.version>
-    <log4j.version>2.17.0</log4j.version>
+    <log4j.version>2.17.1</log4j.version>
   </properties>
 
   <!-- we only need to tell maven where to find our parent pom and other QBiC dependencies -->


### PR DESCRIPTION
1.3.4 (2022-01-04)
-------------------

**Added**

**Fixed**

**Dependencies**

* org.apache.logging.log4j 2.17.0 -> 2.17.1 (addresses CVE-2021-44832)

**Deprecated**